### PR TITLE
A new take on debuginfo

### DIFF
--- a/SPECS/xcp-ng-generic-lib.spec
+++ b/SPECS/xcp-ng-generic-lib.spec
@@ -1,6 +1,10 @@
+# handle debuginfo ourselves to keep the symbols in the main RPM
+# we need this for good stacktraces in production
+%global debug_package %{nil}
+
 Name:           xcp-ng-generic-lib
 Version:        1.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A library of algorithms, I/O and networking functions
 License:        GPLv3
 URL:            https://github.com/xcp-ng/xcp-ng-generic-lib
@@ -10,9 +14,6 @@ BuildRequires:  cmake3
 BuildRequires:  make
 BuildRequires:  gcc
 BuildRequires:  binutils-devel
-
-# debuginfo required for the crash handler to produce relevant stacktraces
-Requires: %{name}-debuginfo = %{version}-%{release}
 
 %description
 A library of algorithms, I/O and networking functions... used by XCP-ng tools or daemons.
@@ -29,11 +30,30 @@ make
 %install
 cd build
 %make_install
+# produce debuginfo stuff: symbols and sources
+%__debug_install_post
 
 %files
 %license LICENSE
 %{_libdir}/libxcp-ng-generic.so.1
 %{_libdir}/libxcp-ng-generic.so.%{version}
+/usr/lib/debug/.build-id/*
+/usr/lib/debug/usr/lib64/*
+
+
+%package debuginfo
+Summary: Debug information for package %{name}
+AutoReqProv: 0
+
+%description debuginfo
+This package provides debug information for package %{name}
+Debug information is useful when developing applications that use this
+package or when debugging this package.
+
+%files debuginfo
+%dir /usr/src/debug/%{name}-%{version}
+/usr/src/debug/%{name}-%{version}/src
+/usr/src/debug/%{name}-%{version}/include
 
 
 %package devel
@@ -61,6 +81,11 @@ This package provides documentation and development headers for xcp-ng-generic-l
 %{_libdir}/libxcp-ng-generic.so
 
 %changelog
+* Tue May 28 2019 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.1.0-2
+- Do not require the debuginfo package anymore
+- Include stripped symbols in the main package
+- Produce a custom debuginfo package containing only the sources
+
 * Tue May 28 2019 Ronan Abhamon <ronan.abhamon@vates.fr> - 1.1.0-1
 - Update to 1.1.0
 


### PR DESCRIPTION
- Do not require debuginfo package (not very clean and Koji doesn't like that)
- Include debug symbols in main package
- Produce a custom debuginfo package with the sources only.